### PR TITLE
Fix create cache tables

### DIFF
--- a/Resources/Private/CreateCacheTables.sql
+++ b/Resources/Private/CreateCacheTables.sql
@@ -1,23 +1,23 @@
 BEGIN;
 
-CREATE TABLE IF NOT EXISTS "cache" (
-  "identifier" VARCHAR(250) NOT NULL,
-  "cache" VARCHAR(250) NOT NULL,
-  "context" VARCHAR(150) NOT NULL,
-  "created" INTEGER UNSIGNED NOT NULL,
-  "lifetime" INTEGER UNSIGNED DEFAULT '0' NOT NULL,
-  "content" LONGTEXT,
-  PRIMARY KEY ("identifier", "cache", "context")
+CREATE TABLE IF NOT EXISTS cache (
+  identifier VARCHAR(250) NOT NULL,
+  cache VARCHAR(250) NOT NULL,
+  context VARCHAR(150) NOT NULL,
+  created INTEGER UNSIGNED NOT NULL,
+  lifetime INTEGER UNSIGNED DEFAULT '0' NOT NULL,
+  content LONGTEXT,
+  PRIMARY KEY (identifier, cache, context)
 ) ENGINE = InnoDB;
 
-CREATE TABLE IF NOT EXISTS "tags" (
-  "identifier" VARCHAR(250) NOT NULL,
-  "cache" VARCHAR(250) NOT NULL,
-  "context" VARCHAR(150) NOT NULL,
-  "tag" VARCHAR(250) NOT NULL
+CREATE TABLE IF NOT EXISTS tags (
+  identifier VARCHAR(250) NOT NULL,
+  cache VARCHAR(250) NOT NULL,
+  context VARCHAR(150) NOT NULL,
+  tag VARCHAR(250) NOT NULL
 ) ENGINE = InnoDB;
 
-CREATE INDEX "identifier" ON "tags" ("identifier", "cache", "context");
-CREATE INDEX "tag" ON "tags" ("tag");
+CREATE INDEX identifier ON tags (identifier, cache, context);
+CREATE INDEX tag ON tags (tag);
 
 COMMIT;


### PR DESCRIPTION
This change removes the double quotes from the SQL creating the cache tables.

With these quotes, my MariaDB 10.2 said: Syntax error or access violation: 1061 Duplicate key name 'identifier'