### PR TITLE
BUGFIX: Do not depend on structure of parent class

### DIFF
--- a/Classes/Cache/PdoBackend.php
+++ b/Classes/Cache/PdoBackend.php
@@ -2,7 +2,6 @@
 namespace Flownative\BeachFlowCompanion\Cache;
 
 use Neos\Flow\Exception;
-use Neos\Flow\Annotations as Flow;
 use Neos\Utility\PdoHelper;
 
 /**
@@ -11,31 +10,24 @@ use Neos\Utility\PdoHelper;
 class PdoBackend extends \Neos\Cache\Backend\PdoBackend
 {
     /**
-     * @Flow\InjectConfiguration(path="persistence.backendOptions", package="Neos.Flow")
-     * @var array
+     * @param array $backendOptions
      */
-    protected $backendOptions;
-
-    /**
-     *
-     */
-    public function initializeObject()
+    public function injectBackendOptions(array $backendOptions)
     {
         $port = '';
-        if (isset($this->backendOptions['port'])) {
-            $port = ';port=' . $this->backendOptions['port'];
+        if (isset($backendOptions['port'])) {
+            $port = ';port=' . $backendOptions['port'];
         }
 
         $this->dataSourceName = sprintf(
             '%s:host=%s;dbname=%s%s',
-            str_replace('pdo_', '', $this->backendOptions['driver']),
-            $this->backendOptions['host'],
-            $this->backendOptions['dbname'],
+            str_replace('pdo_', '', $backendOptions['driver']),
+            $backendOptions['host'],
+            $backendOptions['dbname'],
             $port
         );
-        $this->username = $this->backendOptions['user'];
-        $this->password = $this->backendOptions['password'];
-        parent::initializeObject();
+        $this->username = $backendOptions['user'];
+        $this->password = $backendOptions['password'];
     }
 
     /**

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -1,0 +1,4 @@
+Flownative\BeachFlowCompanion\Cache\PdoBackend:
+  properties:
+    backendOptions:
+      setting: Neos.Flow.persistence.backendOptions


### PR DESCRIPTION
This is a backwards compatible fix for changes in the Flow PdoBackend.
The backend in this class depended on the ``initializeObject`` method
in the parent but that was technically not necessary and with an
inject method for the configuration we make this independent from
it's parent class and any changes of it.

Fixes: #3