### PR TITLE
Improve handling of non-persistent caches

### DIFF
--- a/Classes/Cache/PdoBackend.php
+++ b/Classes/Cache/PdoBackend.php
@@ -2,6 +2,7 @@
 namespace Flownative\BeachFlowCompanion\Cache;
 
 use Neos\Flow\Exception;
+use Neos\Utility\Exception\FilesException;
 use Neos\Utility\PdoHelper;
 
 /**
@@ -31,9 +32,29 @@ class PdoBackend extends \Neos\Cache\Backend\PdoBackend
     }
 
     /**
+     * Checks if the dataSourceName is set, and output a more helpful exception if not.
+     *
      * @return void
      * @throws Exception
      * @throws \Neos\Cache\Exception
+     * @throws FilesException
+     */
+    protected function connect()
+    {
+        if ($this->databaseHandle === null && empty($this->dataSourceName)) {
+            throw new Exception(
+                'Empty DSN in Flownative\BeachFlowCompanion\Cache\PdoBackend. Make sure to configure the backendOptions if using this cache backend with non-persistent caches.',
+                1551434683
+            );
+        }
+        parent::connect();
+    }
+
+    /**
+     * @return void
+     * @throws Exception
+     * @throws \Neos\Cache\Exception
+     * @throws FilesException
      */
     public function createTableIfNeeded()
     {

--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -1,7 +1,7 @@
 <?php
 namespace Flownative\BeachFlowCompanion;
 
-use Flownative\BeachFlowCompanion\Cache\PdoBackend;
+use Flownative\BeachFlowCompanion\Cache\PdoBackend as CompanionPdobackend;
 use Neos\Cache\Exception\NoSuchCacheException;
 use Neos\Flow\Cache\CacheManager;
 use Neos\Flow\Command\CacheCommandController;
@@ -26,7 +26,7 @@ class Package extends \Neos\Flow\Package\Package
                 try {
                     $cacheManager = $bootstrap->getObjectManager()->get(CacheManager::class);
                     foreach ($cacheManager->getCacheConfigurations() as $cacheIdentifier => $cacheConfiguration) {
-                       if (isset($cacheConfiguration['backend']) && $cacheConfiguration['backend'] === PdoBackend::class) {
+                       if (isset($cacheConfiguration['backend']) && $cacheConfiguration['backend'] === CompanionPdobackend::class) {
                            try {
                                $cacheManager->getCache($cacheIdentifier)->getBackend()->createTableIfNeeded();
                            } catch (NoSuchCacheException $e) {

--- a/Configuration/Caches.yaml
+++ b/Configuration/Caches.yaml
@@ -1,5 +1,8 @@
 Flow_Security_Cryptography_HashService:
-  backend: Flownative\BeachFlowCompanion\Cache\PdoBackend
+  backend: Neos\Cache\Backend\PdoBackend
   backendOptions:
+    dataSourceName: 'mysql:host=%env:BEACH_DATABASE_HOST%;dbname=%env:BEACH_DATABASE_NAME%'
+    username: '%env:BEACH_DATABASE_USERNAME%'
+    password: '%env:BEACH_DATABASE_PASSWORD%'
     defaultLifetime: 0
   persistent: true

--- a/Configuration/Caches.yaml
+++ b/Configuration/Caches.yaml
@@ -1,5 +1,5 @@
 Flow_Security_Cryptography_HashService:
-  backend: Neos\Cache\Backend\PdoBackend
+  backend: Flownative\BeachFlowCompanion\Cache\PdoBackend
   backendOptions:
     dataSourceName: 'mysql:host=%env:BEACH_DATABASE_HOST%;dbname=%env:BEACH_DATABASE_NAME%'
     username: '%env:BEACH_DATABASE_USERNAME%'

--- a/Configuration/Caches.yaml
+++ b/Configuration/Caches.yaml
@@ -5,4 +5,3 @@ Flow_Security_Cryptography_HashService:
     username: '%env:BEACH_DATABASE_USERNAME%'
     password: '%env:BEACH_DATABASE_PASSWORD%'
     defaultLifetime: 0
-  persistent: true

--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ Flow_Security_Cryptography_HashService:
 
 **Warning**
 
-The `Flownative\BeachFlowCompanion\Cache\PdoBackend` must only be used for caches
-marked as `persistent`. If used for non-persistent caches, the lack of injection
-for compile-time commands will break any such command, like, ironically,
+It is possible to use the PdoBackend from this package without configuring the DB
+connection directly. It does then fall back to the Doctrine connection configuration
+used for the persistence layer.
+
+If doing so, the `Flownative\BeachFlowCompanion\Cache\PdoBackend` must only be used
+for caches marked as `persistent`. If used for non-persistent caches, the lack of
+injection for compile-time commands will break any such command, like, ironically,
 `flow:cache:flush`.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ This package is easily be replaced by according configuration in Flow 5.2 and up
 
 You should configure your caches for use of the PDO cache backend (like shown below)
 to have the encryption key stored in the database. Or any other cache that is not
-flushed upon deployment. Our [guide on caching with Redis](https://www.flownative.com/en/documentation/guides/beach/how-to-use-redis-for-caching-for-neos-and-flow.html)
-has more details on this.
+flushed upon deployment.
 
 To have the caches set up as needed,  call the `flow:cache:setupall` command in your
 deployment scripts, e.g. after `flow:cache:warmup`.

--- a/README.md
+++ b/README.md
@@ -1,30 +1,63 @@
 [![MIT license](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 [![Packagist](https://img.shields.io/packagist/v/flownative/beach-flow-companion.svg)](https://packagist.org/packages/flownative/beach-flow-companion)
-[![Maintenance level: Love](https://img.shields.io/badge/maintenance-%E2%99%A1%E2%99%A1%E2%99%A1-ff69b4.svg)](https://www.flownative.com/en/products/open-source.html)
+[![Maintenance level: Acquaintance](https://img.shields.io/badge/maintenance-%E2%99%A1-ff69b4.svg)](https://www.flownative.com/en/products/open-source.html)
 
 # Flownative Beach Flow Companion
 
-This package provides convenient configuration and additional tools for Flow applications which are hosted on
+This package provides convenient configuration for Flow applications which are hosted on
 [Flownative Beach](https://www.flownative.com/en/products/beach.html).
 
-In this early version it provides the following functionality:
+It provides the following functionality:
 
 - configure the encryption key to be stored in the database (using the PDO cache backend)
 - automatically create the caching table in the database on `flow:cache:warmup`
 
+## DEPRECATION NOTICE
+
+This package is easily be replaced by according configuration in Flow 5.2 and up.
+
+You should configure your caches for use of the PDO cache backend (like shown below)
+to have the encryption key stored in the database. Or any other cache that is not
+flushed upon deployment. Our [guide on caching with Redis](https://www.flownative.com/en/documentation/guides/beach/how-to-use-redis-for-caching-for-neos-and-flow.html)
+has more details on this.
+
+To have the caches set up as needed,  call the `flow:cache:setupall` command in your
+deployment scripts, e.g. after `flow:cache:warmup`.
+
 ## Installation
 
-If you are using this package in a Flownative Beach project, there's nothing specific you need to do: this package
-is automatically installed via `composer require` when the Docker image of your project is built.
-
-If you want to try out this companion in your development setup, simply require it yourself:
+If you want to use this companion, simply require:
 
 ```bash
-    $ composer require 'flownative/beach-flow-companion:1.*'
+$ composer require 'flownative/beach-flow-companion:1.*'
 ```
 
 In case you are using Flow 3.*, you need to include a version with legacy support:
 
 ```bash
-    $ composer require 'flownative/beach-flow-companion:0.*'
+$ composer require 'flownative/beach-flow-companion:0.*'
 ```
+
+## Configuration
+
+The configuration shipped with the package contains is set up so it will work on
+Flownative Beach right away. If you want to use the package elsewhere, adjust
+the caches configuration as needed, this is the default:
+
+```yaml
+Flow_Security_Cryptography_HashService:
+  backend: Neos\Cache\Backend\PdoBackend
+  backendOptions:
+    dataSourceName: 'mysql:host=%env:BEACH_DATABASE_HOST%;dbname=%env:BEACH_DATABASE_NAME%'
+    username: '%env:BEACH_DATABASE_USERNAME%'
+    password: '%env:BEACH_DATABASE_PASSWORD%'
+    defaultLifetime: 0
+  persistent: true
+```
+
+**Warning**
+
+The `Flownative\BeachFlowCompanion\Cache\PdoBackend` must only be used for caches
+marked as `persistent`. If used for non-persistent caches, the lack of injection
+for compile-time commands will break any such command, like, ironically,
+`flow:cache:flush`.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Flow_Security_Cryptography_HashService:
     username: '%env:BEACH_DATABASE_USERNAME%'
     password: '%env:BEACH_DATABASE_PASSWORD%'
     defaultLifetime: 0
-  persistent: true
 ```
 
 **Warning**

--- a/Resources/Private/CreateCacheTables.sql
+++ b/Resources/Private/CreateCacheTables.sql
@@ -4,17 +4,17 @@ CREATE TABLE IF NOT EXISTS "cache" (
   "identifier" VARCHAR(250) NOT NULL,
   "cache" VARCHAR(250) NOT NULL,
   "context" VARCHAR(150) NOT NULL,
-  "created" INTEGER UNSIGNED NOT NULL,
+  "created" INTEGER UNSIGNED DEFAULT '0' NOT NULL,
   "lifetime" INTEGER UNSIGNED DEFAULT '0' NOT NULL,
-  "content" LONGTEXT,
+  "content" LONGTEXT NOT NULL,
   PRIMARY KEY ("identifier", "cache", "context")
 ) ENGINE = InnoDB;
 
 CREATE TABLE IF NOT EXISTS "tags" (
-  "identifier" VARCHAR(250) NOT NULL,
+  "identifier" VARCHAR(255) NOT NULL,
   "cache" VARCHAR(250) NOT NULL,
   "context" VARCHAR(150) NOT NULL,
-  "tag" VARCHAR(250) NOT NULL,
+  "tag" VARCHAR(255) NOT NULL,
   INDEX "identifier" ("identifier", "cache", "context"),
   INDEX "tag" ("tag")
 ) ENGINE = InnoDB;

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "email": "support@flownative.com"
     },
     "require": {
-        "neos/flow": "^4.0 || ^5.0 || dev-master"
+        "neos/flow": "4.* || 5.0.* || 5.1.*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "email": "support@flownative.com"
     },
     "require": {
-        "neos/flow": "4.* || 5.0.* || 5.1.*"
+        "neos/flow": "4.* || 5.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This improves the handling of non-persistent caches in the contained backend. Also documentation is amended with hints and the default configuration now no longer relies on DI being available for the connection parameter setup (when used within Beach).

Document that the package can easily be replaced by configuration and a CLI command call, so it can be phased out over time.

Fixes #6